### PR TITLE
Allow bpstopall to stop workers even when the manager is not up

### DIFF
--- a/R/RedisBackend-class.R
+++ b/R/RedisBackend-class.R
@@ -188,6 +188,9 @@ setMethod(".send", "RedisBackend",
 setMethod(".close", "RedisBackend",
     function(worker)
 {
+    if (!identical(worker, .redisNULL())) {
+        worker$api_client$QUIT()
+    }
     invisible(NULL)
 })
 
@@ -231,3 +234,5 @@ setMethod(bpworkers, "RedisBackend",
         .all_workers(x)
     }
 })
+
+

--- a/R/RedisParam-methods.R
+++ b/R/RedisParam-methods.R
@@ -82,20 +82,28 @@ NULL
 #########################
 .RedisParam$methods(
     show = function() {
+        ## Temporary disable the log
+        if(bplog(.self)){
+            bplog(.self) <- FALSE
+            on.exit(
+                bplog(.self) <- TRUE
+            )
+        }
+
+
         callSuper()
         running.workers <- length(bpbackend(.self))
         if (is.null(rppassword(.self)))
             .password <- NA_character_
         else
             .password <- "*****"
-
         cat(
             "  rphost: ", rphost(.self),
             "; rpport: ", rpport(.self),
             "; rppassword: ", .password, "\n",
             "  rpisworker: ", rpisworker(.self),
             if (!isTRUE(rpisworker(.self)))
-                "; running workers: ", bpnworkers(bpbackend(.self)),
+                paste0("; running workers: ", bpnworkers(bpbackend(.self))),
             "\n",
             sep = "")
     }
@@ -234,3 +242,12 @@ bpstopall <-
     gc()
     x
 }
+
+
+setReplaceMethod("bplog", c("RedisParam", "logical"),
+                 function(x, value)
+                 {
+                     x$log <- value
+                     x
+                 })
+


### PR DESCRIPTION
Hi Martin, 

Thanks for cleaning up the code, it looks much better! I'm working on the job management for the manager RedisParam. There will be significant changes in RedisBackend, so I hope to merge the previous commits before I can move on. Here are what I did to these commits:

1. Allow `bpstopall` to send the stop message even when the manager is not running.
2. Define the `.close` method for RedisBackend so the worker will not be listed as "connected" when it is actually not.
3. Define the replacement method for `bplog` for internal use only
4. Suppresss the log output in the `show` method
5. Fix inccorectly printed 0 in the worker `show` method.

Best,
Jiefei