### PR TITLE
Allow the manager to resubmit the missing job

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RedisParam
 Title: Provide a 'redis' back-end for BiocParallel
-Version: 0.0.5
+Version: 0.0.6
 Authors@R: c(
     person(
         "Martin", "Morgan",

--- a/R/RedisBackend-class.R
+++ b/R/RedisBackend-class.R
@@ -57,22 +57,34 @@ RedisBackend <-
         port = as.integer(port),
         password = password)
     clientName <- .client_name(jobname, type, id)
-    api_client$CLIENT_SETNAME(clientName)
     job_queue <- paste0("biocparallel_redis_job:", jobname)
     result_queue <- paste0("biocparallel_redis_result:", jobname)
+    worker_list <-paste0("biocparallel_redis_workers:", jobname)
 
-    structure(
+
+    x <- structure(
         list(
             api_client = api_client,
             jobname = jobname,
             job_queue = job_queue,
             result_queue = result_queue,
+            worker_list = worker_list,
             timeout = as.integer(timeout),
             type = type,
             id = id
         ),
         class = "RedisBackend"
     )
+
+    .setClientName(x, clientName)
+    if(type == "worker"){
+        .setAdd(x, worker_list, id)
+    }
+x
+}
+
+.jobCacheQueue <- function(id){
+    paste0("job_cache_queue:", id)
 }
 
 .client_name_prefix <-
@@ -92,68 +104,197 @@ RedisBackend <-
     function(x)
 {
     prefix <- .client_name_prefix(x$jobname, "worker")
-    clients <- x$api_client$CLIENT_LIST()
+    clients <- .listClients(x)
     idx <- gregexpr(paste0(" name=", prefix, ".+? "), clients)
     clientsNames <- regmatches(clients, idx)[[1]]
     ## Remove the prefix and the tailing space
     substring(clientsNames, nchar(prefix) + 7, nchar(clientsNames) - 1)
 }
 
+.wait_until_success <-
+    function(expr, timeout,
+             errorMsg, operationWhileWaiting = NULL)
+{
+    frame <- parent.frame()
+    expr <- substitute(expr)
+    operationWhileWaiting <- substitute(operationWhileWaiting)
+    start_time <- Sys.time()
+    repeat{
+        .value <- eval(expr, envir = frame)
+        if (!is.null(.value)) {
+            break
+        }
+        eval(operationWhileWaiting, envir = frame)
+        wait_time <- difftime(Sys.time(), start_time, units = 'secs')
+        if (wait_time > timeout) {
+            stop(errorMsg)
+        }
+    }
+    .value
+}
+
+## The wrapper function for the Redis APIs
+
+.setClientName <- function(x, name){
+    x$api_client$CLIENT_SETNAME(name)
+}
+
+.listClients <- function(x){
+    x$api_client$CLIENT_LIST()
+}
+
+.quit <- function(x){
+    x$api_client$QUIT()
+}
+
+.push_raw <- function(x, queue, value){
+     x$api_client$LPUSH(
+        key = queue,
+        value = value
+    )
+}
+
+.pop_raw <- function(x, queue, timeout = 1L){
+     x$api_client$BRPOP(
+            key = queue,
+            timeout = timeout
+        )
+}
+
+.move <- function(x, source, dest, timeout = 1L){
+    value <- x$api_client$BRPOPLPUSH(
+        source = source,
+        destination = dest,
+        timeout = timeout
+    )
+    if(is.null(value))
+        NULL
+    else
+        unserialize(value)
+}
+
+.delete <- function(x, key){
+    x$api_client$DEL(key)
+}
+
+.queueLen <- function(x, key){
+    x$api_client$LLEN(key)
+}
+
+.setAdd <- function(x, key, values){
+    x$api_client$SADD(key, values)
+}
+
+.setValues <- function(x, key){
+    unlist(x$api_client$SSCAN(key, 0, COUNT = .Machine$integer.max)[[2]])
+}
+
+.setRemove <- function(x, key, values){
+    x$api_client$SREM(key, values)
+}
+
+## The high level function built upon the wrappers
 .push <-
-    function(x, queue_name, value)
+    function(x, queue, value)
 {
     value <- serialize(value, NULL, xdr = FALSE)
-    x$api_client$RPUSH(
-        key = queue_name,
+    .push_raw(
+        x,
+        queue = queue,
         value = value
     )
 }
 
 .pop <-
-    function(x, queue_name)
+    function(x, queue, raw = FALSE)
 {
-    value <- NULL
-    start_time <- Sys.time()
-    repeat{
-        value <- x$api_client$BLPOP(
-            key = queue_name,
-            timeout = 1
-        )
-        if (!is.null(value)) {
-            break
-        }
-        wait_time <- difftime(Sys.time(), start_time, units = 'secs')
-        if (wait_time > x$timeout) {
-            stop("Redis pop operation timeout")
-        }
-    }
+    value <- .wait_until_success(
+        .pop_raw(
+            x,
+            queue = queue
+        ),
+        timeout = x$timeout,
+        errorMsg = "Redis pop operation timeout"
+    )
     unserialize(value[[2]])
 }
 
-## push_* and pop_* depend on push and pop
-.push_job <-
-    function(x, value)
-{
-    .push(x, x$job_queue, value)
+.resubmit_missing_jobs <- function(x){
+    queueName <- x$result_queue
+    workerList <- x$worker_list
+    connectedWorkers <- bpworkers(x)
+    registeredWorkers <- .setValues(x, workerList)
+    deadWorkers <- setdiff(registeredWorkers, connectedWorkers)
+    ## If there are dead workers, we check if they have any job
+    for(id in deadWorkers){
+        cacheQueue <- .jobCacheQueue(id)
+        queueLen <- .queueLen(x, cacheQueue)
+        ## queueLen is 1 means it is running a job
+        if (queueLen == 1) {
+            message("A missing job is found, resubmitting")
+            .move(
+                x,
+                source = cacheQueue,
+                dest = x$job_queue
+            )
+        }else{
+            if (queueLen != 0L) {
+                warning("Corrupted job queue for a worker is found!")
+                .delete(x, cacheQueue)
+            }
+        }
+    }
 }
 
-.pop_job <-
-    function(x)
-{
-    .pop(x, c(x$job_queue, x$id))
-}
-
-.push_result <-
-    function(x, value)
-{
-    .push(x, x$result_queue, value)
+.pop_job <- function(x){
+    cacheQueue <- .jobCacheQueue(x$id)
+    id <- x$id
+    .wait_until_success({
+        queueName <- ifelse(
+            .queueLen(x, id) == 0,
+            x$job_queue,
+            id)
+        .move(
+            x,
+            source = queueName,
+            dest = cacheQueue
+        )
+    }
+    ,
+    timeout = Inf,
+    errorMsg = "Redis pop operation timeout"
+    )
 }
 
 .pop_result <-
     function(x)
 {
-    .pop(x, x$result_queue)
+    value <- .wait_until_success(
+        .pop_raw(
+            x,
+            queue = x$result_queue
+        ),
+        timeout = x$timeout,
+        errorMsg = "Redis pop operation timeout",
+        operationWhileWaiting = .resubmit_missing_jobs(x)
+    )
+    unserialize(value[[2]])
 }
+
+# .push_job <-
+#     function(x, value)
+# {
+#     .push(x, x$job_queue, value)
+# }
+
+.push_result <-
+    function(x, value)
+{
+    cacheQueue <- .jobCacheQueue(x$id)
+    .delete(x, cacheQueue)
+    .push(x, x$result_queue, value)
+}
+
 
 #' @export
 length.RedisBackend <-
@@ -189,7 +330,7 @@ setMethod(".close", "RedisBackend",
     function(worker)
 {
     if (!identical(worker, .redisNULL())) {
-        worker$api_client$QUIT()
+        .quit(worker)
     }
     invisible(NULL)
 })
@@ -235,4 +376,17 @@ setMethod(bpworkers, "RedisBackend",
     }
 })
 
+## Show the job queue status
+## For debugging purpose only
+bpstatus <- function(x){
+    if(is(x, "RedisParam"))
+        x <- bpbackend(x)
+    jobs <- .queueLen(x, x$job_queue)
+    workers <- .setValues(x, x$worker_list)
+    workerStatus <- lapply(
+        workers,
+        function(id) .queueLen(x, .jobCacheQueue(id))
+    )
+    list(jobs = jobs, workers = workers, workerStatus = workerStatus)
+}
 

--- a/R/RedisBackend-class.R
+++ b/R/RedisBackend-class.R
@@ -87,7 +87,9 @@ RedisBackend <-
 }
 
 ## Naming rule
-.jobCacheQueue <- function(id){
+.jobCacheQueue <-
+    function(id)
+{
     paste0("job_cache_queue:", id)
 }
 
@@ -127,19 +129,27 @@ RedisBackend <-
 }
 
 ## Redis APIs
-.setClientName <- function(x, name){
+.setClientName <-
+    function(x, name)
+{
     x$api_client$CLIENT_SETNAME(name)
 }
 
-.listClients <- function(x){
+.listClients <-
+    function(x)
+{
     x$api_client$CLIENT_LIST()
 }
 
-.quit <- function(x){
+.quit <-
+    function(x)
+{
     x$api_client$QUIT()
 }
 
-.push <- function(x, queue, value){
+.push <-
+    function(x, queue, value)
+{
     value <- serialize(value, NULL, xdr = FALSE)
      x$api_client$LPUSH(
         key = queue,
@@ -147,7 +157,9 @@ RedisBackend <-
     )
 }
 
-.move <- function(x, source, dest, timeout = 1L){
+.move <-
+    function(x, source, dest, timeout = 1L)
+{
     value <- x$api_client$BRPOPLPUSH(
         source = source,
         destination = dest,
@@ -159,28 +171,40 @@ RedisBackend <-
         unserialize(value)
 }
 
-.delete <- function(x, key){
+.delete <-
+    function(x, key)
+{
     x$api_client$DEL(key)
 }
 
-.queueLen <- function(x, key){
+.queueLen <-
+    function(x, key)
+{
     x$api_client$LLEN(key)
 }
 
-.setAdd <- function(x, key, values){
+.setAdd <-
+    function(x, key, values)
+{
     x$api_client$SADD(key, values)
 }
 
-.setValues <- function(x, key){
+.setValues <-
+    function(x, key)
+{
     unlist(x$api_client$SSCAN(key, 0, COUNT = .Machine$integer.max)[[2]])
 }
 
-.setRemove <- function(x, key, values){
+.setRemove <-
+    function(x, key, values)
+{
     x$api_client$SREM(key, values)
 }
 
 ## The high level function built upon the wrappers
-.initializeWorker <- function(x){
+.initializeWorker <-
+    function(x)
+{
     if (x$clientName %in% .allWorkers(x)) {
         stop("Name conflict has been found for the worker <", x$id,">")
     }
@@ -192,7 +216,9 @@ RedisBackend <-
     }
 }
 
-.initializeManager <- function(x){
+.initializeManager <-
+    function(x)
+{
     deadWorkers <- .listDeadWorkers(x)
     for (id in deadWorkers) {
         if (.isWorkerBusy(x, id)) {
@@ -239,7 +265,9 @@ RedisBackend <-
     .setRemove(x, workerQueue, workerId)
 }
 
-.resubmitMissingJobs <- function(x){
+.resubmitMissingJobs <-
+    function(x)
+{
     deadWorkers <- .listDeadWorkers(x)
     if (length(deadWorkers)>0) {
         message(length(deadWorkers), " workers are missing from the job queue.")
@@ -260,11 +288,15 @@ RedisBackend <-
     }
 }
 
-.pushJob <- function(x, workerId, value){
+.pushJob <-
+    function(x, workerId, value)
+{
     .push(x, workerId, value)
 }
 
-.popJob <- function(x){
+.popJob <-
+    function(x)
+{
     cacheQueue <- .jobCacheQueue(x$id)
     id <- x$id
     .wait_until_success({
@@ -390,9 +422,11 @@ setMethod(bpworkers, "RedisBackend",
     }
 })
 
-## Show the job queue status
+## Show the backend status
 ## For debugging purpose only
-bpstatus <- function(x){
+bpstatus <-
+    function(x)
+{
     if(is(x, "RedisParam"))
         x <- bpbackend(x)
     njobs <- .queueLen(x, x$jobQueue)

--- a/R/RedisParam-accessors.R
+++ b/R/RedisParam-accessors.R
@@ -21,7 +21,7 @@ NULL
 #'
 #'     `rppassword()` reads an (optional) password from the system
 #'     environment variable "REDIS_PASSWORD", defaulting to
-#'     `NA_character_` (no password). `rppassword(x)` gives the password
+#'     `NULL` (no password). `rppassword(x)` gives the password
 #'      used by `x`.
 #'
 #' @export
@@ -80,7 +80,7 @@ rppassword <-
     function(x)
 {
     if (missing(x)) {
-        Sys.getenv("REDIS_PASSWORD", NA_character_)
+        Sys.getenv("REDIS_PASSWORD", NULL)
     } else {
         value <- x$password
         if (is.na(value)) {

--- a/R/RedisParam-accessors.R
+++ b/R/RedisParam-accessors.R
@@ -80,14 +80,14 @@ rppassword <-
     function(x)
 {
     if (missing(x)) {
-        Sys.getenv("REDIS_PASSWORD", NULL)
+        value <- Sys.getenv("REDIS_PASSWORD", NA_character_)
     } else {
         value <- x$password
-        if (is.na(value)) {
-            NULL
-        } else {
-            value
-        }
+    }
+    if (is.na(value)) {
+        NULL
+    } else {
+        value
     }
 }
 

--- a/R/RedisParam-class.R
+++ b/R/RedisParam-class.R
@@ -103,7 +103,7 @@ RedisParam <-
 {
     if (!is.null(RNGseed))
         RNGseed <- as.integer(RNGseed)
-    if (!nzchar(redis.password)) {
+    if (!nzchar(redis.password)||is.null(redis.password)) {
         redis.password <- NA_character_
     }
 

--- a/tests/testthat/test_RedisBackend.R
+++ b/tests/testthat/test_RedisBackend.R
@@ -1,0 +1,50 @@
+skip_if_not(rpalive(RedisParam(1L)))
+
+jobname <- "test_RedisBackend"
+manager <- NULL
+worker1 <- NULL
+worker2 <- NULL
+
+
+
+test_that("Creating RedisBackend", {
+    expect_error(manager <<- RedisBackend(jobname = jobname, type = "manager"), NA)
+    expect_error(worker1 <<- RedisBackend(jobname = jobname, type = "worker"), NA)
+    expect_error(worker2 <<- RedisBackend(jobname = jobname, type = "worker"), NA)
+})
+
+test_that("Check workers", {
+    expect_equal(length(manager), 2L)
+    expect_true(
+        setequal(
+            bpworkers(manager),
+            c(worker1$id,worker2$id)
+        )
+    )
+})
+
+test_that("job dispatching function", {
+    jobValue <- "job message"
+    resultValue <- "result message"
+    expect_error(.send_to(manager, 1, jobValue), NA)
+    expect_equal(.recv(worker1), jobValue)
+    expect_error(.pushResult(worker1, resultValue), NA)
+    expect_equal(.popResult(manager), resultValue)
+})
+
+test_that("Job management", {
+    jobValue <- "job message"
+    resultValue <- "result message"
+    expect_error(.send_to(manager, 1, jobValue), NA)
+    expect_equal(.recv(worker1), jobValue)
+    ## kill worker1
+    .close(worker1)
+    .resubmitMissingJobs(manager)
+    ## Receive the job from worker2
+    expect_equal(.recv(worker2), jobValue)
+    expect_error(.pushResult(worker2, resultValue), NA)
+    expect_equal(.popResult(manager), resultValue)
+})
+
+
+


### PR DESCRIPTION
Hello Martin,

This pull request allows the manager to actively manage the job queue. It is done by adding a cache queue for each worker. When a worker receives a task, it will also push the task to the cache queue. When waiting for the result, the manager will regularly check the worker's status. If a worker disappears for some reason, its task will be retrieved from the cache queue and resubmitted to the job queue. Here are the changes in the commits

1. Add the job management
2. Create initializer functions for the manager and workers to check the integrity of the job queue in Redis.
3. Convert the variable and function names to camelCase in RedisBackend
4. Add the unit test for the backend

The plan for this week will be moving the Redis operation to the Lua script. Our current implementation uses a combination of the Redis operations in each function. The cost of the operation can be high if the network is not stable. We can save the round trip time by grouping the Redis operation together as a single command. It is not easy to use the Redis MULTI command to combine the operations as our code contains logic operations, so we need the Lua script.

A known issue is that when the manager is waiting for the result from the result queue and is interrupted by the user, the result queue will be contaminated by the old results returned from the worker. This can make the next call to `.recv_any` receive the previous invalid result. I think this should be a common problem in parallel execution. While the user interrupts the manager's execution, we need to interrupt the worker's execution as well. It looks like this issue has been solved for SnowParam. For example
```
library(BiocParallel)
s <- SnowParam(workers = 2)
bpstart(s)
## run and immediately interupt
bplapply(1:2, function(i) {Sys.sleep(20);Sys.getpid()}, BPPARAM = r)
## The workers are ready for the next task and the results are not contaminated
bplapply(1:2, function(i) i, BPPARAM = r)
```
Surprisingly, I can find the related code in neither `BiocParallel` nor `parallel`. This might be implemented in `socketSelect` in `parallel:::recvOneData.SOCKcluster` as I can only reproduce the same issue if I interrupt the R session before calling this function. The function is implemented in C and I'm still working on it. Please let me know if you have any thoughts.

Best,
Jiefei