### PR TITLE
Fix a bug in calling the .error function

### DIFF
--- a/R/RedisParam-accessors.R
+++ b/R/RedisParam-accessors.R
@@ -63,6 +63,7 @@ rpport <-
         port <- as.integer(value)
         if (is.na(port)) {
             .error(
+                x,
                 "The 'REDIS_PORT' environment variable cannot be coerced to an integer. The original value was '%s'.",
                 value
             )

--- a/R/RedisParam-methods.R
+++ b/R/RedisParam-methods.R
@@ -229,7 +229,7 @@ bpstopall <-
     .trace(x, "bpstopall")
 
     if (isTRUE(rpisworker(x))) {
-        .error("use 'bpstopall()' from manager, not worker")
+        .error(x, "use 'bpstopall()' from manager, not worker")
     }
 
     if (!bpisup(x)) {


### PR DESCRIPTION
Some code calls the .error function with incorrect arguments. This is a simple fix for them.

Best,
Jiefei