### PR TITLE
Change the name of the environment variable in RedisParam

### DIFF
--- a/R/RedisParam-accessors.R
+++ b/R/RedisParam-accessors.R
@@ -12,15 +12,15 @@ NULL
 #'     maximum (currently 1000) if workers are listening on a queue.
 #'
 #'     `rphost()` reads the host name of the redis server from a
-#'     system environment variable `"REDIS_HOST"`, defaulting to
-#'     `"127.0.0.1"`. `rphost(x)` gives the host name used by `x`.
+#'     system environment variable `"REDISPARAM_HOST"`,
+#'      defaulting to `"127.0.0.1"`. `rphost(x)` gives the host name used by `x`.
 #'
 #'     `rpport()` reads the port of the redis server from a system
-#'     environment variable `"REDIS_PORT"`, defaulting to 6379.
-#'     `rpport(x)` gives the port used by `x`.
+#'     environment variable `REDISPARAM_PORT`,
+#'     defaulting to 6379. `rpport(x)` gives the port used by `x`.
 #'
 #'     `rppassword()` reads an (optional) password from the system
-#'     environment variable "REDIS_PASSWORD", defaulting to
+#'     environment variable `REDISPARAM_PASSWORD`, defaulting to
 #'     `NA_character_` (no password). `rppassword(x)` gives the password
 #'      used by `x`.
 #'
@@ -46,7 +46,7 @@ rphost <-
     function(x)
 {
     if (missing(x)) {
-        Sys.getenv("REDIS_HOST", "127.0.0.1")
+        Sys.getenv("REDISPARAM_HOST", "127.0.0.1")
     } else {
         x$hostname
     }
@@ -59,11 +59,11 @@ rpport <-
     function(x)
 {
     if (missing(x)) {
-        value <- Sys.getenv("REDIS_PORT", "6379")
+        value <- Sys.getenv("REDISPARAM_PORT", "6379")
         port <- as.integer(value)
         if (is.na(port)) {
             .error(
-                "The 'REDIS_PORT' environment variable cannot be coerced to an integer. The original value was '%s'.",
+                "The 'REDISPARAM_PORT' environment variable cannot be coerced to an integer. The original value was '%s'.",
                 value
             )
         }
@@ -80,7 +80,7 @@ rppassword <-
     function(x)
 {
     if (missing(x)) {
-        Sys.getenv("REDIS_PASSWORD", NA_character_)
+        Sys.getenv("REDISPARAM_PASSWORD", NA_character_)
     } else {
         value <- x$password
         if (is.na(value)) {

--- a/R/RedisParam-accessors.R
+++ b/R/RedisParam-accessors.R
@@ -11,16 +11,20 @@ NULL
 #'     `snowWorkers()` if workers are created dynamically, or a fixed
 #'     maximum (currently 1000) if workers are listening on a queue.
 #'
-#'     `rphost()` reads the host name of the redis server from a
-#'     system environment variable `"REDISPARAM_HOST"`,
-#'      defaulting to `"127.0.0.1"`. `rphost(x)` gives the host name used by `x`.
+#'     `rphost()` reads the host name of the Redis server from the
+#'     system environment variable `REDISPARAM_HOST`, if the variable is
+#'     not defined, fallback to `REDIS_HOST`. Otherwise default to
+#'     `"127.0.0.1"`.
+#'     `rphost(x)` gives the host name used by `x`.
 #'
-#'     `rpport()` reads the port of the redis server from a system
-#'     environment variable `REDISPARAM_PORT`,
-#'     defaulting to 6379. `rpport(x)` gives the port used by `x`.
+#'     `rpport()` reads the port of the Redis server from a system
+#'     environment variable `REDISPARAM_PORT`, if the variable is
+#'     not defined, fallback to `REDIS_PORT`. Otherwise default to
+#'     `6379`. `rpport(x)` gives the port used by `x`.
 #'
 #'     `rppassword()` reads an (optional) password from the system
-#'     environment variable `REDISPARAM_PASSWORD`, defaulting to
+#'     environment variable `REDISPARAM_PASSWORD`, if the variable is
+#'     not defined, fallback to `REDIS_PASSWORD`. Otherwise default to
 #'     `NA_character_` (no password). `rppassword(x)` gives the password
 #'      used by `x`.
 #'
@@ -46,7 +50,9 @@ rphost <-
     function(x)
 {
     if (missing(x)) {
-        Sys.getenv("REDISPARAM_HOST", "127.0.0.1")
+        value <- Sys.getenv("REDIS_HOST", "127.0.0.1")
+        value <- Sys.getenv("REDISPARAM_HOST", value)
+        value
     } else {
         x$hostname
     }
@@ -59,7 +65,8 @@ rpport <-
     function(x)
 {
     if (missing(x)) {
-        value <- Sys.getenv("REDISPARAM_PORT", "6379")
+        value <- Sys.getenv("REDIS_PORT", "6379")
+        value <- Sys.getenv("REDISPARAM_PORT", value)
         port <- as.integer(value)
         if (is.na(port)) {
             .error(
@@ -80,7 +87,9 @@ rppassword <-
     function(x)
 {
     if (missing(x)) {
-        Sys.getenv("REDISPARAM_PASSWORD", NA_character_)
+        value <- Sys.getenv("REDIS_PASSWORD", NA_character_)
+        value <- Sys.getenv("REDISPARAM_PASSWORD", value)
+        value
     } else {
         value <- x$password
         if (is.na(value)) {

--- a/R/RedisParam-accessors.R
+++ b/R/RedisParam-accessors.R
@@ -67,6 +67,11 @@ rpport <-
     if (missing(x)) {
         value <- Sys.getenv("REDIS_PORT", "6379")
         value <- Sys.getenv("REDISPARAM_PORT", value)
+        ## extract the trailing number
+        ## Support the format like "tcp://10.19.242.166:6379"
+        if(nzchar(value) && grepl("[^0-9]", value)){
+            value <- gsub("^.*[^0-9]","", value)
+        }
         port <- as.integer(value)
         if (is.na(port)) {
             .error(

--- a/R/RedisParam-class.R
+++ b/R/RedisParam-class.R
@@ -43,15 +43,16 @@
 #'     & workers on a queue.
 #'
 #' @param redis.hostname character(1) host name of redis server,
-#'     from system environment variable `REDISPARAM_HOST` or,
-#'     by default `"127.0.0.1"`.
+#'     from system environment variable `REDISPARAM_HOST` or `REDIS_HOST`,
+#'     if both are not defined, the default `"127.0.0.1"` is used.
 #'
 #' @param redis.port integer(1) port of redis server, from system
-#'     environment variable `REDISPARAM_PORT` or, by default 6379.
+#'     environment variable `REDISPARAM_PORT` or `REDIS_PORT`,
+#'     if both are not defined, the default `6379` is used.
 #'
 #' @param redis.password character(1) or NULL, host password of redis server
-#'     from system environment variable `REDISPARAM_PASSWORD` or,
-#'     by default, `NA_character_` (no password).
+#'     from system environment variable `REDISPARAM_PASSWORD` or `REDIS_PASSWORD`,
+#'     if both are not defined, the default `NA_character_` (no password) is used.
 #'
 #' @param is.worker logical(1) \code{bpstart()} creates worker-only
 #'     (\code{TRUE}), manager-only (\code{FALSE}), or manager and

--- a/R/RedisParam-class.R
+++ b/R/RedisParam-class.R
@@ -43,14 +43,15 @@
 #'     & workers on a queue.
 #'
 #' @param redis.hostname character(1) host name of redis server,
-#'     from system environment variable `REDIS_HOST` or, by default,
-#'     `"127.0.0.1"`.
+#'     from system environment variable `REDISPARAM_HOST` or,
+#'     by default `"127.0.0.1"`.
 #'
 #' @param redis.port integer(1) port of redis server, from system
-#'     environment variable `REDIS_PORT` or, by default, 6379.
+#'     environment variable `REDISPARAM_PORT` or, by default 6379.
 #'
 #' @param redis.password character(1) or NULL, host password of redis server
-#'     or, by default, `NA_character_` (no password).
+#'     from system environment variable `REDISPARAM_PASSWORD` or,
+#'     by default, `NA_character_` (no password).
 #'
 #' @param is.worker logical(1) \code{bpstart()} creates worker-only
 #'     (\code{TRUE}), manager-only (\code{FALSE}), or manager and

--- a/man/RedisParam-class.Rd
+++ b/man/RedisParam-class.Rd
@@ -92,14 +92,15 @@ number of workers opened by `bpstart()`.}
 \item{RNGseed}{See `?"BiocParallelParam-class"`.}
 
 \item{redis.hostname}{character(1) host name of redis server,
-from system environment variable `REDIS_HOST` or, by default,
-`"127.0.0.1"`.}
+from system environment variable `REDISPARAM_HOST` or,
+by default `"127.0.0.1"`.}
 
 \item{redis.port}{integer(1) port of redis server, from system
-environment variable `REDIS_PORT` or, by default, 6379.}
+environment variable `REDISPARAM_PORT` or, by default 6379.}
 
 \item{redis.password}{character(1) or NULL, host password of redis server
-or, by default, `NA_character_` (no password).}
+from system environment variable `REDISPARAM_PASSWORD` or,
+by default, `NA_character_` (no password).}
 
 \item{is.worker}{logical(1) \code{bpstart()} creates worker-only
 (\code{TRUE}), manager-only (\code{FALSE}), or manager and
@@ -147,15 +148,15 @@ Use an instance of `RedisParam()` for interactive parallel
     maximum (currently 1000) if workers are listening on a queue.
 
     `rphost()` reads the host name of the redis server from a
-    system environment variable `"REDIS_HOST"`, defaulting to
-    `"127.0.0.1"`. `rphost(x)` gives the host name used by `x`.
+    system environment variable `"REDISPARAM_HOST"`,
+     defaulting to `"127.0.0.1"`. `rphost(x)` gives the host name used by `x`.
 
     `rpport()` reads the port of the redis server from a system
-    environment variable `"REDIS_PORT"`, defaulting to 6379.
-    `rpport(x)` gives the port used by `x`.
+    environment variable `REDISPARAM_PORT`,
+    defaulting to 6379. `rpport(x)` gives the port used by `x`.
 
     `rppassword()` reads an (optional) password from the system
-    environment variable "REDIS_PASSWORD", defaulting to
+    environment variable `REDISPARAM_PASSWORD`, defaulting to
     `NA_character_` (no password). `rppassword(x)` gives the password
      used by `x`.
 

--- a/man/RedisParam-class.Rd
+++ b/man/RedisParam-class.Rd
@@ -92,15 +92,16 @@ number of workers opened by `bpstart()`.}
 \item{RNGseed}{See `?"BiocParallelParam-class"`.}
 
 \item{redis.hostname}{character(1) host name of redis server,
-from system environment variable `REDISPARAM_HOST` or,
-by default `"127.0.0.1"`.}
+from system environment variable `REDISPARAM_HOST` or `REDIS_HOST`,
+if both are not defined, the default `"127.0.0.1"` is used.}
 
 \item{redis.port}{integer(1) port of redis server, from system
-environment variable `REDISPARAM_PORT` or, by default 6379.}
+environment variable `REDISPARAM_PORT` or `REDIS_PORT`,
+if both are not defined, the default `6379` is used.}
 
 \item{redis.password}{character(1) or NULL, host password of redis server
-from system environment variable `REDISPARAM_PASSWORD` or,
-by default, `NA_character_` (no password).}
+from system environment variable `REDISPARAM_PASSWORD` or `REDIS_PASSWORD`,
+if both are not defined, the default `NA_character_` (no password) is used.}
 
 \item{is.worker}{logical(1) \code{bpstart()} creates worker-only
 (\code{TRUE}), manager-only (\code{FALSE}), or manager and
@@ -147,16 +148,20 @@ Use an instance of `RedisParam()` for interactive parallel
     `snowWorkers()` if workers are created dynamically, or a fixed
     maximum (currently 1000) if workers are listening on a queue.
 
-    `rphost()` reads the host name of the redis server from a
-    system environment variable `"REDISPARAM_HOST"`,
-     defaulting to `"127.0.0.1"`. `rphost(x)` gives the host name used by `x`.
+    `rphost()` reads the host name of the Redis server from the
+    system environment variable `REDISPARAM_HOST`, if the variable is
+    not defined, fallback to `REDIS_HOST`. Otherwise default to
+    `"127.0.0.1"`.
+    `rphost(x)` gives the host name used by `x`.
 
-    `rpport()` reads the port of the redis server from a system
-    environment variable `REDISPARAM_PORT`,
-    defaulting to 6379. `rpport(x)` gives the port used by `x`.
+    `rpport()` reads the port of the Redis server from a system
+    environment variable `REDISPARAM_PORT`, if the variable is
+    not defined, fallback to `REDIS_PORT`. Otherwise default to
+    `6379`. `rpport(x)` gives the port used by `x`.
 
     `rppassword()` reads an (optional) password from the system
-    environment variable `REDISPARAM_PASSWORD`, defaulting to
+    environment variable `REDISPARAM_PASSWORD`, if the variable is
+    not defined, fallback to `REDIS_PASSWORD`. Otherwise default to
     `NA_character_` (no password). `rppassword(x)` gives the password
      used by `x`.
 

--- a/tests/testthat/test_RedisParam-class.R
+++ b/tests/testthat/test_RedisParam-class.R
@@ -1,7 +1,9 @@
 test_that("RedisParam constructor works", {
     ## Test if the environment variables work as we expect
     p <- withr::with_envvar(
-        c(REDIS_HOST = "1.2.3.4", REDIS_PORT = 123L, REDIS_PASSWORD = "123"),
+        c(REDISPARAM_HOST = "1.2.3.4",
+          REDISPARAM_PORT = 123L,
+          REDISPARAM_PASSWORD = "123"),
         RedisParam()
     )
     expect_identical("1.2.3.4", rphost(p))

--- a/tests/testthat/test_RedisParam-class.R
+++ b/tests/testthat/test_RedisParam-class.R
@@ -1,14 +1,45 @@
 test_that("RedisParam constructor works", {
-    ## Test if the environment variables work as we expect
+    ## Test if the environment variables `REDISPARAM_XX` work as we expect
     p <- withr::with_envvar(
         c(REDISPARAM_HOST = "1.2.3.4",
           REDISPARAM_PORT = 123L,
-          REDISPARAM_PASSWORD = "123"),
+          REDISPARAM_PASSWORD = "123",
+          REDIS_HOST = "",
+          REDIS_PORT = "",
+          REDIS_PASSWORD = ""),
         RedisParam()
     )
     expect_identical("1.2.3.4", rphost(p))
     expect_identical(123L, rpport(p))
     expect_identical("123", rppassword(p))
+
+    ## Test if the fallback environment variables `REDIS_XX` work as we expect
+    p <- withr::with_envvar(
+        c(REDISPARAM_HOST = "",
+          REDISPARAM_PORT = "",
+          REDISPARAM_PASSWORD = "",
+          REDIS_HOST = "1.2.3.4",
+          REDIS_PORT = 123L,
+          REDIS_PASSWORD = "123"),
+        RedisParam()
+    )
+    expect_identical("1.2.3.4", rphost(p))
+    expect_identical(123L, rpport(p))
+    expect_identical("123", rppassword(p))
+
+    ## Test if the default constructor work as we expect
+    p <- withr::with_envvar(
+        c(REDISPARAM_HOST = "",
+          REDISPARAM_PORT = "",
+          REDISPARAM_PASSWORD = "",
+          REDIS_HOST = "",
+          REDIS_PORT = "",
+          REDIS_PASSWORD = ""),
+        RedisParam()
+    )
+    expect_identical("127.0.0.1", rphost(p))
+    expect_identical(6379L, rpport(p))
+    expect_identical(NULL, rppassword(p))
 
     ## Test the default constructor
     ## There might exist environment variables


### PR DESCRIPTION
We saw that in Nitash's k8s node `REDIS_PORT` has a little different meaning.
```
> Sys.getenv('REDIS_PORT')
[1] "tcp://10.19.242.166:6379"
```
the name `REDIS_HOST` and `REDIS_PORT` are not very specific to our package, so I suggest using the prefix `REDISPARAM` in the environment variables to avoid the possible conflict. This commit revises the names in the function, document, and unit test in the package.

Best,
Jiefei