### PR TITLE
Fix a typo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RedisParam
 Title: Provide a 'redis' back-end for BiocParallel
-Version: 0.99.0
+Version: 0.99.1
 Authors@R: c(
     person(
         "Martin", "Morgan",

--- a/R/RedisParam-class.R
+++ b/R/RedisParam-class.R
@@ -251,6 +251,6 @@ rpstopall <-
 bpstopall <-
     function(x)
 {
-    .Deprecated("bpstopall")
+    .Deprecated("rpstopall")
     rpstopall(x)
 }


### PR DESCRIPTION
Right now our deprecation message is like this, so I made a quick fix
```
> bpstopall(param)
Warning message:
'bpstopall' is deprecated.
Use 'bpstopall' instead.
See help("Deprecated") 
```